### PR TITLE
Exlude wwwroot from build

### DIFF
--- a/Server/src/Server/project.json
+++ b/Server/src/Server/project.json
@@ -32,7 +32,10 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true
+    "preserveCompilationContext": true,
+    "compile": {
+      "exclude": [ "wwwroot" ]
+    }
   },
 
   "runtimeOptions": {


### PR DESCRIPTION
Fix build and exlude wwwroot folder from build where is a lot of typescript and other stuff that we don't need track. 